### PR TITLE
Add Azure AI Foundry Hub to bicep

### DIFF
--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -1,0 +1,39 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('Name of the Foundry Hub')
+param foundryHubName string = 'foundryHub'
+
+@description('Resource ID of the container registry')
+param containerRegistryResourceId string
+
+@description('Resource ID of the Application Insights instance')
+param applicationInsightsResourceId string
+
+@description('Resource ID of the Key Vault')
+param keyVaultResourceId string
+
+resource aiHub 'Microsoft.MachineLearningServices/workspaces@2023-08-01-preview' = {
+  name: foundryHubName
+  location: location
+  kind: 'hub'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    description: 'Azure AI Foundry Hub'
+    friendlyName: 'AI Foundry Hub'
+    publicNetworkAccess: 'Enabled'
+    containerRegistry: containerRegistryResourceId
+    applicationInsights: applicationInsightsResourceId
+    keyVault: keyVaultResourceId
+  }
+  tags: tags
+}
+
+output resourceId string = aiHub.id
+output name string = aiHub.name
+output principalId string = aiHub.identity.principalId

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -561,9 +561,25 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
     ]
   }
 }
+
+// Deploy the Foundry Hub from the module
+module foundryHub './modules/ai-services.bicep' = {
+  name: 'foundry-hub'
+  params: {
+    location: location
+    tags: tags
+    foundryHubName:  '${abbrs.machineLearningServicesWorkspaces}${resourceToken}'
+    containerRegistryResourceId: containerRegistry.outputs.resourceId
+    applicationInsightsResourceId: monitoring.outputs.applicationInsightsResourceId
+    keyVaultResourceId: keyVault.outputs.resourceId 
+  }
+}
+
 output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.loginServer
 output AZURE_KEY_VAULT_ENDPOINT string = keyVault.outputs.uri
 output AZURE_KEY_VAULT_NAME string = keyVault.outputs.name
+output AZURE_FOUNDRY_HUB_NAME string = foundryHub.outputs.name
+output AZURE_FOUNDRY_HUB_ID string = foundryHub.outputs.resourceId
 output AZURE_RESOURCE_CHUNK_VIDEO_CONTENT_ID string = chunkVideoContent.outputs.resourceId
 output AZURE_RESOURCE_INDEX_FILE_API_ID string = indexFileApi.outputs.resourceId
 output AZURE_RESOURCE_SUMMARIZE_VIDEO_CONTENT_ID string = summarizeVideoContent.outputs.resourceId


### PR DESCRIPTION
- Added a new file `ai-services.bicep`. The goal is that this file will be the future home of other resources such as the Azure AI Services (with Content Understanding) and Azure AI Foundry Project when API support arrives.
- Added AI Foundry Hub resource to the new file
- Referenced the new file in `resources.bicep`