### PR TITLE
fixed blocking issue in analysis service

### DIFF
--- a/core/services/llm_video_analysis_service.py
+++ b/core/services/llm_video_analysis_service.py
@@ -1,6 +1,6 @@
 import logging
 
-from openai import OpenAI
+from openai import AsyncAzureOpenAI
 
 from core.exceptions import RetryQueueingException
 from core.models import VideoUploadMetadata, ContentResult, Content, VideoSubjects
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 class LLMVideoAnalysisService:
 
-    def __init__(self, openai_service: OpenAI, openai_model_name: str) -> None:
+    def __init__(self, openai_service: AsyncAzureOpenAI, openai_model_name: str) -> None:
         self.openai_service = openai_service
         self.openai_model_name = openai_model_name
-
+        
     async def find_video_subjects(
             self,
             content_result: ContentResult,
@@ -54,7 +54,7 @@ class LLMVideoAnalysisService:
             combined_summary = "\n".join(summaries)
 
             # Create a comprehensive summary by sending a request to Azure OpenAI's chat completion endpoint
-            response = self.openai_service.beta.chat.completions.parse(
+            response = await self.openai_service.beta.chat.completions.parse(
                 response_format=VideoSubjects,
                 model=self.openai_model_name,
                 messages=[
@@ -160,7 +160,7 @@ class LLMVideoAnalysisService:
             initial_subjects_json = initial_subjects.model_dump_json(indent=2)
 
             # Ask OpenAI to assess and optionally improve the subject list
-            response = self.openai_service.beta.chat.completions.parse(
+            response = await self.openai_service.beta.chat.completions.parse(
                 response_format=VideoSubjects,
                 model=self.openai_model_name,
                 messages=[
@@ -260,7 +260,7 @@ class LLMVideoAnalysisService:
             combined_summary = "\n".join(summaries)
 
             # Create a comprehensive summary by sending a request to Azure OpenAI's chat completion endpoint
-            response = self.openai_service.chat.completions.create(
+            response = await self.openai_service.chat.completions.create(
                 model=self.openai_model_name,
                 messages=[
                     {

--- a/core/services/service_bus_event_messaging_service.py
+++ b/core/services/service_bus_event_messaging_service.py
@@ -5,6 +5,8 @@ import logging
 from typing import Callable
 from datetime import datetime, timezone, timedelta
 
+from concurrent.futures import ThreadPoolExecutor
+
 from azure.servicebus import ServiceBusMessage
 from azure.servicebus.aio import ServiceBusClient, AutoLockRenewer
 
@@ -141,6 +143,16 @@ class ServiceBusEventMessagingService(EventMessagingService):
             self.logger.exception(f"Failed to schedule message to queue '{queue_name}': {e}")
             raise
 
+    async def lock_renewal_failure_handler(self, renewable, error):
+        """
+        Handles lock renewal failures for messages.
+
+        Args:
+            renewable: The message that failed to renew its lock.
+            error: The error that occurred during lock renewal.
+        """
+        self.logger.warning(f"Failed to renew lock for message: {renewable}. Error: {error}")
+
     async def process_messages(
             self,
             queue_name: str,
@@ -157,9 +169,10 @@ class ServiceBusEventMessagingService(EventMessagingService):
             message_handler (Callable): A coroutine function to handle individual messages.
         """
         try:
+            renewer = AutoLockRenewer(max_lock_renewal_duration=1200, on_lock_renew_failure=self.lock_renewal_failure_handler)  # Handles automatic lock renewal for messages
+
             # Asynchronously create a receiver for the specified queue
             async with self.service_bus_client.get_queue_receiver(queue_name=queue_name) as receiver:
-                renewer = AutoLockRenewer()  # Handles automatic lock renewal for messages
                 self.logger.info(f"Started processing messages from queue '{queue_name}'.")
                 try:
                     while not stop_event.is_set():
@@ -176,7 +189,7 @@ class ServiceBusEventMessagingService(EventMessagingService):
                         for msg in messages:
                             try:
                                 # Register the message with the renewer to handle lock renewal
-                                renewer.register(receiver, msg)
+                                renewer.register(receiver, msg, max_lock_renewal_duration=1200)
 
                                 correlation_id = msg.application_properties.get(b"correlationId")
                                 trace_id = msg.application_properties.get(b"traceId")
@@ -186,7 +199,9 @@ class ServiceBusEventMessagingService(EventMessagingService):
                                 )
 
                                 # Delegate processing to the provided message_handler coroutine
+                                self.logger.debug("Delegating message processing to the message handler.")
                                 await message_handler(msg)
+                                self.logger.debug("Delegated message processing completed.")
 
                                 # Complete the message to remove it from the queue
                                 await receiver.complete_message(message=msg)
@@ -211,7 +226,7 @@ class ServiceBusEventMessagingService(EventMessagingService):
                                 )
                                 # Log that the message has been requeued
                                 self.logger.info("Message requeued successfully.")
-                            except FatalQueueingException or Exception as e:
+                            except (FatalQueueingException, Exception) as e:
                                 correlation_id = msg.application_properties.get(b"correlationId")
                                 trace_id = msg.application_properties.get(b"traceId")
                                 self.logger.exception(

--- a/summarize_video_content/container.py
+++ b/summarize_video_content/container.py
@@ -1,7 +1,7 @@
 import logging
 
 from dependency_injector import containers, providers
-from openai import AzureOpenAI
+from openai import AsyncAzureOpenAI
 
 from core import create_service_bus_client, create_azure_credential, create_azure_ad_token
 from core.services import ServiceBusEventMessagingService, ContentUnderstandingClient, AzureBlobFileUploadService, \
@@ -63,14 +63,14 @@ class Container(containers.DeclarativeContainer):
     )
 
     openai_service_key_auth = providers.Singleton(
-        AzureOpenAI,
+        AsyncAzureOpenAI,
         api_key=config.azure_openai_key,
         api_version=config.azure_openai_api_version,
         azure_endpoint=config.azure_openai_endpoint
     )
 
     openai_service_managed_identity_auth = providers.Singleton(
-        AzureOpenAI,
+        AsyncAzureOpenAI,
         azure_ad_token=azure_ad_token_resource,
         api_version=config.azure_openai_api_version,
         azure_endpoint=config.azure_openai_endpoint


### PR DESCRIPTION
This issue was causing Service Bus to not be able to renew it's locks.  Swapped "OpenAI" library for "AsyncAzureOpenAI"  (Although could have used just "AsyncOpenAI".)

This took all the gosh darn day to figure out.  Thanks to @petemessina for helping me out.

This pull request includes significant updates to integrate the `AsyncAzureOpenAI` service instead of the `OpenAI` service and improve the handling of message processing in the `ServiceBusEventMessagingService`. The most important changes are detailed below:

### Integration of `AsyncAzureOpenAI`:

* [`core/services/llm_video_analysis_service.py`](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L3-R3): Replaced the `OpenAI` service with `AsyncAzureOpenAI` and updated methods to use `await` for asynchronous operations. [[1]](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L3-R3) [[2]](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L13-R13) [[3]](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L57-R57) [[4]](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L163-R163) [[5]](diffhunk://#diff-6129ad8035550c9295ec5f768c0c3fe865dd3bdf6f8f01e8354146a714d02697L263-R263)
* [`summarize_video_content/container.py`](diffhunk://#diff-4210eeac7869570adc3055ceb2723a1810b6d427336460791ec8780f928b0d9aL4-R4): Updated dependency injection to use `AsyncAzureOpenAI` instead of `AzureOpenAI`. [[1]](diffhunk://#diff-4210eeac7869570adc3055ceb2723a1810b6d427336460791ec8780f928b0d9aL4-R4) [[2]](diffhunk://#diff-4210eeac7869570adc3055ceb2723a1810b6d427336460791ec8780f928b0d9aL66-R73)

### Improvements to message processing:

* [`core/services/service_bus_event_messaging_service.py`](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520R8-R9): Added `lock_renewal_failure_handler` to handle lock renewal failures and updated `AutoLockRenewer` usage with a failure handler and `max_lock_renewal_duration` parameter. [[1]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520R8-R9) [[2]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520R146-R155) [[3]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520R172-L162) [[4]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520L179-R192) [[5]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520R202-R204) [[6]](diffhunk://#diff-00f75b98c263fed4dda7f89b350b4e4ebaca1dd3ff5a6cc271c23c05e06f5520L214-R229)