### PR TITLE
fixed bug that threw errors if auth to Open AI with key and not MI

### DIFF
--- a/core/src/services/__init__.py
+++ b/core/src/services/__init__.py
@@ -42,12 +42,17 @@ async def create_service_bus_client(endpoint: str, credential: any, logger: any)
         client = None  # Ensure the client is reset
 
 # we need to extract a token for the AzureOpenAI client if we're going to connect via Managed Identity
-async def create_azure_ad_token():
-    credential = DefaultAzureCredential()
-    token_provider = get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
-    token = await token_provider()
-    yield token
-    await credential.close()
+async def create_azure_ad_token(openai_auth_type: str):
+    if openai_auth_type == "managed_identity":
+        logger.debug("Creating Azure AD token provider for Managed Identity")
+        credential = DefaultAzureCredential()
+        token_provider = get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default")
+        token = await token_provider()
+        yield token
+        await credential.close()
+    else:
+        logger.debug("No Azure AD token provider needed for API key authentication")
+        yield None
 
 async def create_content_understanding_http_client_session(key: str, logger: Optional[any]):
     headers = {

--- a/summarize_video_content/src/container.py
+++ b/summarize_video_content/src/container.py
@@ -67,7 +67,8 @@ class Container(containers.DeclarativeContainer):
     )
 
     azure_ad_token_resource = providers.Resource(
-        create_azure_ad_token
+        create_azure_ad_token,
+        config.azure_openai_auth_type
     )
 
     openai_service_key_auth = providers.Singleton(


### PR DESCRIPTION
Authentication mechanism updates:

* [`core/src/services/__init__.py`](diffhunk://#diff-28a54bf71abda60a15bd6d6b3039348706ed54e05745bf4c8362f3a4355263d6L45-R55): Modified `create_azure_ad_token` to accept an `openai_auth_type` parameter and added logic to handle different authentication types.

Dependency injection updates:

* [`summarize_video_content/src/container.py`](diffhunk://#diff-175c9b3ce292f272cb858908e82e48cdc04ae2230ca4d58671d0f44f73ee5206L70-R71): Updated the `azure_ad_token_resource` provider in the `Container` class to pass the new `openai_auth_type` configuration parameter to the `create_azure_ad_token` function.