### PR TITLE
feat: add storage account and queues to bicep

### DIFF
--- a/infra/app-modules/chunk-video-content.bicep
+++ b/infra/app-modules/chunk-video-content.bicep
@@ -32,6 +32,15 @@ param chunkVideoContentSecrets array
 @description('Environment variables for the app')
 param chunkVideoContentEnvVars array
 
+@description('Service Bus namespace name')
+param serviceBusNamespaceName string
+
+@description('Storage account name')
+param storageAccountName string
+
+@description('Blob container name')
+param blobContainerName string
+
 // Deploy Chunk Video Content Container App
 module chunkVideoContent '../modules/container-app.bicep' = {
   name: 'chunkVideoContentContainerApp'
@@ -50,6 +59,71 @@ module chunkVideoContent '../modules/container-app.bicep' = {
     envVars: chunkVideoContentEnvVars
     imageName: 'chunk-video-content'
   }
+  dependsOn: [
+    finalizeContentQueue   // Ensure the finalize-content queue exists
+    indexFileQueue         // Ensure the index-file queue exists
+    blobContainer          // Ensure the blob container exists
+  ]
+}
+
+// Reference to the finalize-content queue
+resource finalizeContentQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' existing = {
+  name: '${serviceBusNamespaceName}/finalize-content'
+}
+
+// Reference to the index-file queue
+resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' existing = {
+  name: '${serviceBusNamespaceName}/index-file'
+}
+
+// Reference to the blob container
+resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' existing = {
+  name: '${storageAccountName}/default/${blobContainerName}'
+}
+
+// Grant write access to the finalize content queue
+resource writeAccessToFinalizeContentQueue 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (chunkVideoContentExists) {
+  name: guid(finalizeContentQueue.id, chunkVideoContentIdentityClientId, 'Sender')
+  scope: finalizeContentQueue
+  properties: {
+    principalId: chunkVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39') // Azure Service Bus Data Sender
+    principalType: 'ServicePrincipal'
+    description: 'Grant Chunk Video Content app write access to the finalize-content queue'
+  }
+  dependsOn: [
+    chunkVideoContent // Ensure container app is deployed before role assignment
+  ]
+}
+
+// Grant read access to the index file queue
+resource readAccessToIndexFileQueue 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (chunkVideoContentExists) {
+  name: guid(indexFileQueue.id, chunkVideoContentIdentityClientId, 'Receiver')
+  scope: indexFileQueue
+  properties: {
+    principalId: chunkVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0') // Azure Service Bus Data Receiver
+    principalType: 'ServicePrincipal'
+    description: 'Grant Chunk Video Content app read access to the index-file queue'
+  }
+  dependsOn: [
+    chunkVideoContent // Ensure container app is deployed before role assignment
+  ]
+}
+
+// Grant Storage Blob Data Contributor access to the blob container
+resource blobContainerContributorAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (chunkVideoContentExists) {
+  name: guid(blobContainer.id, chunkVideoContentIdentityClientId, 'BlobContributor')
+  scope: blobContainer
+  properties: {
+    principalId: chunkVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe') // Storage Blob Data Contributor
+    principalType: 'ServicePrincipal'
+    description: 'Grant Chunk Video Content app read/write access to the blob container'
+  }
+  dependsOn: [
+    chunkVideoContent // Ensure container app is deployed before role assignment
+  ]
 }
 
 output resourceId string = chunkVideoContent.outputs.resourceId

--- a/infra/app-modules/index-file-api.bicep
+++ b/infra/app-modules/index-file-api.bicep
@@ -32,6 +32,9 @@ param indexFileApiSecrets array
 @description('Environment variables for the app')
 param indexFileApiEnvVars array
 
+@description('Service Bus namespace name')
+param serviceBusNamespaceName string
+
 // Deploy Index File API Container App
 module indexFileApi '../modules/container-app.bicep' = {
   name: 'indexFileApiContainerApp'
@@ -50,6 +53,29 @@ module indexFileApi '../modules/container-app.bicep' = {
     envVars: indexFileApiEnvVars
     imageName: 'index-file-api'
   }
+  dependsOn: [
+    indexFileQueue  // Ensure the index-file queue exists
+  ]
+}
+
+// Reference to the index-file queue
+resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' existing = {
+  name: '${serviceBusNamespaceName}/index-file'
+}
+
+// Grant write access to the index file queue
+resource writeAccessToIndexFileQueue 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (indexFileApiExists) {
+  name: guid(indexFileQueue.id, indexFileApiIdentityClientId, 'Sender')
+  scope: indexFileQueue
+  properties: {
+    principalId: indexFileApiIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39') // Azure Service Bus Data Sender
+    principalType: 'ServicePrincipal'
+    description: 'Grant Index File API app write access to the index-file queue'
+  }
+  dependsOn: [
+    indexFileApi // Ensure container app is deployed before role assignment
+  ]
 }
 
 output resourceId string = indexFileApi.outputs.resourceId

--- a/infra/app-modules/summarize-video-content.bicep
+++ b/infra/app-modules/summarize-video-content.bicep
@@ -32,6 +32,15 @@ param summarizeVideoContentSecrets array
 @description('Environment variables for the app')
 param summarizeVideoContentEnvVars array
 
+@description('Service Bus namespace name')
+param serviceBusNamespaceName string
+
+@description('Storage account name')
+param storageAccountName string
+
+@description('Blob container name')
+param blobContainerName string
+
 // Deploy Summarize Video Content Container App
 module summarizeVideoContent '../modules/container-app.bicep' = {
   name: 'summarizeVideoContentContainerApp'
@@ -50,6 +59,71 @@ module summarizeVideoContent '../modules/container-app.bicep' = {
     envVars: summarizeVideoContentEnvVars
     imageName: 'summarize-video-content'
   }
+  dependsOn: [
+    finalizeContentQueue   // Ensure the finalize-content queue exists
+    videoSummaryQueue      // Ensure the video-summary queue exists
+    blobContainer          // Ensure the blob container exists
+  ]
+}
+
+// Reference to the finalize-content queue
+resource finalizeContentQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' existing = {
+  name: '${serviceBusNamespaceName}/finalize-content'
+}
+
+// Reference to the video-summary queue (need to create this queue in service-bus.bicep)
+resource videoSummaryQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' existing = {
+  name: '${serviceBusNamespaceName}/video-summary'
+}
+
+// Reference to the blob container
+resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' existing = {
+  name: '${storageAccountName}/default/${blobContainerName}'
+}
+
+// Grant read access to the finalize content queue
+resource readAccessToFinalizeContentQueue 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (summarizeVideoContentExists) {
+  name: guid(finalizeContentQueue.id, summarizeVideoContentIdentityClientId, 'Receiver')
+  scope: finalizeContentQueue
+  properties: {
+    principalId: summarizeVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0') // Azure Service Bus Data Receiver
+    principalType: 'ServicePrincipal'
+    description: 'Grant Summarize Video Content app read access to the finalize-content queue'
+  }
+  dependsOn: [
+    summarizeVideoContent // Ensure container app is deployed before role assignment
+  ]
+}
+
+// Grant write access to the video summary queue
+resource writeAccessToVideoSummaryQueue 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (summarizeVideoContentExists) {
+  name: guid(videoSummaryQueue.id, summarizeVideoContentIdentityClientId, 'Sender')
+  scope: videoSummaryQueue
+  properties: {
+    principalId: summarizeVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39') // Azure Service Bus Data Sender
+    principalType: 'ServicePrincipal'
+    description: 'Grant Summarize Video Content app write access to the video-summary queue'
+  }
+  dependsOn: [
+    summarizeVideoContent // Ensure container app is deployed before role assignment
+  ]
+}
+
+// Grant Storage Blob Data Reader access to the blob container
+resource blobContainerReaderAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (summarizeVideoContentExists) {
+  name: guid(blobContainer.id, summarizeVideoContentIdentityClientId, 'BlobReader')
+  scope: blobContainer
+  properties: {
+    principalId: summarizeVideoContentIdentityClientId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1') // Storage Blob Data Reader
+    principalType: 'ServicePrincipal'
+    description: 'Grant Summarize Video Content app read access to the blob container'
+  }
+  dependsOn: [
+    summarizeVideoContent // Ensure container app is deployed before role assignment
+  ]
 }
 
 output resourceId string = summarizeVideoContent.outputs.resourceId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -93,7 +93,6 @@ module resources 'resources.bicep' = {
     summarizeVideoContentExists: summarizeVideoContentExists
     summarizeVideoContentDefinition: summarizeVideoContentDefinition
     // Pass the parameters to resources.bicep
-    serviceBusNamespace: serviceBusNamespace
     serviceBusApiKey: serviceBusApiKey
     serviceBusApiKeyName: serviceBusApiKeyName
     contentUnderstandingEndpoint: contentUnderstandingEndpoint

--- a/infra/modules/core-infrastructure.bicep
+++ b/infra/modules/core-infrastructure.bicep
@@ -10,6 +10,9 @@ param managedIdentityPrincipalIds array = []
 @description('ID of the user or app to assign access policies for Key Vault')
 param principalId string
 
+@description('Name of the blob container to create in the storage account')
+param blobContainerName string = 'videos'
+
 var abbrs = loadJsonContent('../abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
 
@@ -84,6 +87,34 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
   }
 }
 
+// Deploy Storage Account
+module storageAccount 'br/public:avm/res/storage/storage-account:0.6.0' = {
+  name: 'storage'
+  params: {
+    name: '${abbrs.storageStorageAccounts}${resourceToken}'
+    location: location
+    tags: tags
+    kind: 'StorageV2'
+    skuName: 'Standard_LRS'
+    publicNetworkAccess: 'Enabled'
+    allowBlobPublicAccess: false
+    defaultToOAuthAuthentication: true
+    roleAssignments: [for principalId in managedIdentityPrincipalIds: {
+      principalId: principalId
+      principalType: 'ServicePrincipal'
+      roleDefinitionIdOrName: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe') // Storage Blob Data Contributor
+    }]
+  }
+}
+
+// Create Blob Container in Storage Account
+resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  name: '${abbrs.storageStorageAccounts}${resourceToken}/default/${blobContainerName}'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
 output logAnalyticsWorkspaceResourceId string = monitoring.outputs.logAnalyticsWorkspaceResourceId
 output applicationInsightsResourceId string = monitoring.outputs.applicationInsightsResourceId
 output applicationInsightsConnectionString string = monitoring.outputs.applicationInsightsConnectionString
@@ -93,3 +124,7 @@ output containerAppsEnvironmentResourceId string = containerAppsEnvironment.outp
 output keyVaultResourceId string = keyVault.outputs.resourceId
 output keyVaultUri string = keyVault.outputs.uri
 output keyVaultName string = keyVault.outputs.name
+output storageAccountResourceId string = storageAccount.outputs.resourceId
+output storageAccountName string = storageAccount.outputs.name
+output blobContainerName string = blobContainerName
+output blobEndpoint string = storageAccount.outputs.primaryBlobEndpoint

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -1,0 +1,90 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('Principal IDs for managed identities that need access to the service bus')
+param managedIdentityPrincipalIds array = []
+
+@description('Resource token for unique resource naming')
+param resourceToken string
+
+@description('Name prefix abbreviations')
+param abbrs object
+
+// Deploy Service Bus Namespace
+module serviceBus 'br/public:avm/res/service-bus/namespace:0.4.0' = {
+  name: 'service-bus'
+  params: {
+    name: '${abbrs.serviceBusNamespaces}${resourceToken}'
+    location: location
+    tags: tags
+    skuObject: {
+      name: 'Standard'
+      capacity: 1
+    }
+    roleAssignments: [for principalId in managedIdentityPrincipalIds: {
+      principalId: principalId
+      principalType: 'ServicePrincipal'
+      roleDefinitionIdOrName: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0') // Service Bus Data Sender
+    }]
+  }
+}
+
+// Create a queue for indexing files
+resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = {
+  name: '${abbrs.serviceBusNamespaces}${resourceToken}/index-file'
+  properties: {
+    lockDuration: 'PT5M'
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    defaultMessageTimeToLive: 'P14D'
+    deadLetteringOnMessageExpiration: true
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+    maxDeliveryCount: 10
+    enablePartitioning: false
+    enableExpress: false
+  }
+}
+
+// Create a queue for finalizing content
+resource finalizeContentQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = {
+  name: '${abbrs.serviceBusNamespaces}${resourceToken}/finalize-content'
+  properties: {
+    lockDuration: 'PT5M'
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    defaultMessageTimeToLive: 'P14D'
+    deadLetteringOnMessageExpiration: true
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+    maxDeliveryCount: 10
+    enablePartitioning: false
+    enableExpress: false
+  }
+}
+
+// Create a queue for video summary
+resource videoSummaryQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = {
+  name: '${abbrs.serviceBusNamespaces}${resourceToken}/video-summary'
+  properties: {
+    lockDuration: 'PT5M'
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    defaultMessageTimeToLive: 'P14D'
+    deadLetteringOnMessageExpiration: true
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+    maxDeliveryCount: 10
+    enablePartitioning: false
+    enableExpress: false
+  }
+}
+
+output serviceBusNamespaceName string = serviceBus.outputs.name
+output serviceBusEndpoint string = '${serviceBus.outputs.name}.servicebus.windows.net'
+output indexFileQueueName string = 'index-file'
+output finalizeContentQueueName string = 'finalize-content'
+output videoSummaryQueueName string = 'video-summary'

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -18,8 +18,6 @@ param summarizeVideoContentDefinition object
 param principalId string
 
 // Parameters added for service bus secrets
-@description('Service Bus Namespace')
-param serviceBusNamespace string = ''
 @secure()
 @description('Service Bus API Key')
 param serviceBusApiKey string = ''
@@ -75,11 +73,26 @@ module coreInfra './modules/core-infrastructure.bicep' = {
   }
 }
 
+// Deploy Service Bus infrastructure
+module serviceBusInfra './modules/service-bus.bicep' = {
+  name: 'service-bus-infrastructure'
+  params: {
+    location: location
+    tags: tags
+    managedIdentityPrincipalIds: identities.outputs.managedIdentityPrincipalIds
+    resourceToken: resourceToken
+    abbrs: abbrs
+  }
+}
+
 // Define secrets by group
 var serviceBusSecrets = [
-  { name: 'service-bus-namespace', value: !empty(serviceBusNamespace) ? serviceBusNamespace : 'placeholder-value' }
+  { name: 'service-bus-namespace', value: serviceBusInfra.outputs.serviceBusEndpoint }
   { name: 'service-bus-api-key', value: !empty(serviceBusApiKey) ? serviceBusApiKey : 'placeholder-value' }
   { name: 'service-bus-api-key-name', value: !empty(serviceBusApiKeyName) ? serviceBusApiKeyName : 'placeholder-value' }
+  { name: 'index-file-queue', value: serviceBusInfra.outputs.indexFileQueueName }
+  { name: 'finalize-content-queue', value: serviceBusInfra.outputs.finalizeContentQueueName }
+  { name: 'video-summary-queue', value: serviceBusInfra.outputs.videoSummaryQueueName }
 ]
 
 var contentSecrets = [
@@ -97,6 +110,8 @@ var openAISecrets = [
 
 var storageSecrets = [
   { name: 'storage-account-api-key', value: !empty(storageAccountApiKey) ? storageAccountApiKey : 'placeholder-value' }
+  { name: 'storage-account-name', value: coreInfra.outputs.storageAccountName }
+  { name: 'storage-container-name', value: coreInfra.outputs.blobContainerName }
 ]
 
 // Combine secrets by service
@@ -109,9 +124,13 @@ var chunkVideoContentEnvVars = [
   { name: 'SERVICE_BUS_NAMESPACE', secretRef: 'service-bus-namespace' }
   { name: 'SERVICE_BUS_API_KEY', secretRef: 'service-bus-api-key' }
   { name: 'SERVICE_BUS_API_KEY_NAME', secretRef: 'service-bus-api-key-name' }
+  { name: 'INDEX_FILE_QUEUE', secretRef: 'index-file-queue' }
+  { name: 'FINALIZE_CONTENT_QUEUE', secretRef: 'finalize-content-queue' }
   { name: 'CONTENT_UNDERSTANDING_ENDPOINT', secretRef: 'content-understanding-endpoint' }
   { name: 'CONTENT_UNDERSTANDING_KEY', secretRef: 'content-understanding-key' }
   { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-versio' }
+  { name: 'STORAGE_ACCOUNT_NAME', secretRef: 'storage-account-name' }
+  { name: 'STORAGE_CONTAINER_NAME', secretRef: 'storage-container-name' }
   { name: 'STORAGE_ACCOUNT_API_KEY', secretRef: 'storage-account-api-key' }
 ]
 
@@ -119,12 +138,15 @@ var indexFileApiEnvVars = [
   { name: 'SERVICE_BUS_NAMESPACE', secretRef: 'service-bus-namespace' }
   { name: 'SERVICE_BUS_API_KEY', secretRef: 'service-bus-api-key' }
   { name: 'SERVICE_BUS_API_KEY_NAME', secretRef: 'service-bus-api-key-name' }
+  { name: 'INDEX_FILE_QUEUE', secretRef: 'index-file-queue' }
 ]
 
 var summarizeVideoContentEnvVars = [
   { name: 'SERVICE_BUS_NAMESPACE', secretRef: 'service-bus-namespace' }
   { name: 'SERVICE_BUS_API_KEY', secretRef: 'service-bus-api-key' }
   { name: 'SERVICE_BUS_API_KEY_NAME', secretRef: 'service-bus-api-key-name' }
+  { name: 'FINALIZE_CONTENT_QUEUE', secretRef: 'finalize-content-queue' }
+  { name: 'VIDEO_SUMMARY_QUEUE', secretRef: 'video-summary-queue' }
   { name: 'AZURE_OPENAI_ENDPOINT', secretRef: 'azure-openai-endpoint' }
   { name: 'AZURE_OPENAI_KEY', secretRef: 'azure-openai-key' }
   { name: 'AZURE_OPENAI_API_VERSION', secretRef: 'azure-openai-api-version' }
@@ -132,6 +154,8 @@ var summarizeVideoContentEnvVars = [
   { name: 'CONTENT_UNDERSTANDING_ENDPOINT', secretRef: 'content-understanding-endpoint' }
   { name: 'CONTENT_UNDERSTANDING_KEY', secretRef: 'content-understanding-key' }
   { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-versio' }
+  { name: 'STORAGE_ACCOUNT_NAME', secretRef: 'storage-account-name' }
+  { name: 'STORAGE_CONTAINER_NAME', secretRef: 'storage-container-name' }
   { name: 'STORAGE_ACCOUNT_API_KEY', secretRef: 'storage-account-api-key' }
 ]
 
@@ -150,6 +174,9 @@ module chunkVideoContentApp './app-modules/chunk-video-content.bicep' = {
     chunkVideoContentIdentityClientId: identities.outputs.chunkVideoContentIdentityClientId
     chunkVideoContentSecrets: chunkVideoContentSecrets
     chunkVideoContentEnvVars: chunkVideoContentEnvVars
+    serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
+    storageAccountName: coreInfra.outputs.storageAccountName
+    blobContainerName: coreInfra.outputs.blobContainerName
   }
 }
 
@@ -167,6 +194,7 @@ module indexFileApiApp './app-modules/index-file-api.bicep' = {
     indexFileApiIdentityClientId: identities.outputs.indexFileApiIdentityClientId
     indexFileApiSecrets: indexFileApiSecrets
     indexFileApiEnvVars: indexFileApiEnvVars
+    serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
   }
 }
 
@@ -184,6 +212,9 @@ module summarizeVideoContentApp './app-modules/summarize-video-content.bicep' = 
     summarizeVideoContentIdentityClientId: identities.outputs.summarizeVideoContentIdentityClientId
     summarizeVideoContentSecrets: summarizeVideoContentSecrets
     summarizeVideoContentEnvVars: summarizeVideoContentEnvVars
+    serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
+    storageAccountName: coreInfra.outputs.storageAccountName
+    blobContainerName: coreInfra.outputs.blobContainerName
   }
 }
 
@@ -217,3 +248,10 @@ output AZURE_GPT4O_DEPLOYMENT_NAME string = aiServices.outputs.gpt4oDeploymentNa
 output AZURE_RESOURCE_CHUNK_VIDEO_CONTENT_ID string = chunkVideoContentApp.outputs.resourceId
 output AZURE_RESOURCE_INDEX_FILE_API_ID string = indexFileApiApp.outputs.resourceId
 output AZURE_RESOURCE_SUMMARIZE_VIDEO_CONTENT_ID string = summarizeVideoContentApp.outputs.resourceId
+output AZURE_SERVICE_BUS_NAMESPACE string = serviceBusInfra.outputs.serviceBusNamespaceName
+output AZURE_SERVICE_BUS_ENDPOINT string = serviceBusInfra.outputs.serviceBusEndpoint
+output AZURE_INDEX_FILE_QUEUE string = serviceBusInfra.outputs.indexFileQueueName
+output AZURE_FINALIZE_CONTENT_QUEUE string = serviceBusInfra.outputs.finalizeContentQueueName
+output AZURE_VIDEO_SUMMARY_QUEUE string = serviceBusInfra.outputs.videoSummaryQueueName
+output AZURE_STORAGE_ACCOUNT_NAME string = coreInfra.outputs.storageAccountName
+output AZURE_STORAGE_CONTAINER_NAME string = coreInfra.outputs.blobContainerName

--- a/next-steps.md
+++ b/next-steps.md
@@ -55,22 +55,6 @@ data.json:
 }
 ```
 
-### Azure Storage Account
-
-An Azure Storage Blob account should be created with default configurations.
-A container needs to then be created to act as ephemeral storage for the applications.
-
-### Azure Service Bus
-
-An Azure Service Bus instance needs to be created with 3 different queues.
-
-#### Index Blob Event Queue
-
-#### Upload File Event Queue
-
-#### Video Summarized Event Queue
-
-
 ## Next Steps
 
 ### Provision infrastructure and deploy application code


### PR DESCRIPTION
- Add storage account and blob container to bicep. Include permissions in individual app files where needed.
- Add service bus namespace and queues to bicep. Include permissions in individual app files where needed.
- Update `next-steps.md` to remove manual steps.