### PR TITLE
feat: populate secrets from resource outputs, remove params

### DIFF
--- a/infra/app-modules/chunk-video-content.bicep
+++ b/infra/app-modules/chunk-video-content.bicep
@@ -10,13 +10,6 @@ param applicationInsightsResourceId string
 @description('Resource ID of the Container App Environment')
 param containerAppsEnvironmentResourceId string
 
-@description('Whether the app exists')
-param chunkVideoContentExists bool
-
-@description('Definition of the app')
-@secure()
-param chunkVideoContentDefinition object
-
 @description('Secrets for the app')
 @secure()
 param chunkVideoContentSecrets object
@@ -41,6 +34,9 @@ param abbrs object
 
 @description('Name of the app')
 param name string = 'chunkVideoContent'
+
+@description('Key Vault name')
+param keyVaultName string
 
 // Create managed identities for the container apps
 module identity 'br/public:avm/res/managed-identity/user-assigned-identity:0.2.1' = {
@@ -70,19 +66,6 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.1.1' =
   }
 }
 
-// Remove the separate ACR pull role assignment module
-
-// Grant Storage Blob Data Contributor role to the identity
-module storageBlobContributorRole '../modules/roles/storage-blob-contributor-role.bicep' = if (!empty(storageAccountName)) {
-  name: '${name}-storage-blob-contributor-role'
-  params: {
-    storageAccountName: storageAccountName
-    containerName: blobContainerName
-    principalId: identity.outputs.principalId
-    appName: name
-  }
-}
-
 // Deploy Chunk Video Content Container App
 module chunkVideoContent '../modules/container-app.bicep' = {
   name: 'chunkVideoContentContainerApp'
@@ -93,8 +76,6 @@ module chunkVideoContent '../modules/container-app.bicep' = {
     applicationInsightsResourceId: applicationInsightsResourceId
     containerAppsEnvironmentResourceId: containerAppsEnvironmentResourceId
     containerRegistryLoginServer: containerRegistry.outputs.loginServer
-    exists: chunkVideoContentExists
-    appDefinition: chunkVideoContentDefinition
     identityResourceId: identity.outputs.resourceId
     identityClientId: identity.outputs.clientId
     secrets: chunkVideoContentSecrets
@@ -102,6 +83,7 @@ module chunkVideoContent '../modules/container-app.bicep' = {
     imageName: 'chunk-video-content'
   }
   dependsOn: [
+    keyVaultSecretUserRole    // Ensure Key Vault Secret User role exists
     storageBlobContributorRole   // Ensure Storage Blob role exists
     finalizeContentQueue         // Ensure the finalize-content queue exists
     indexFileQueue               // Ensure the index-file queue exists
@@ -125,7 +107,7 @@ resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/container
 }
 
 // Grant write access to the finalize content queue using the module
-module finalizeSenderRole '../modules/roles/service-bus-sender-role.bicep' = if (chunkVideoContentExists) {
+module finalizeSenderRole '../modules/roles/service-bus-sender-role.bicep' = {
   name: '${name}-finalize-sender-role'
   params: {
     serviceBusNamespaceName: serviceBusNamespaceName
@@ -140,7 +122,7 @@ module finalizeSenderRole '../modules/roles/service-bus-sender-role.bicep' = if 
 }
 
 // Grant read access to the index file queue using the module
-module indexReceiverRole '../modules/roles/service-bus-receiver-role.bicep' = if (chunkVideoContentExists) {
+module indexReceiverRole '../modules/roles/service-bus-receiver-role.bicep' = {
   name: '${name}-index-receiver-role'
   params: {
     serviceBusNamespaceName: serviceBusNamespaceName
@@ -152,6 +134,28 @@ module indexReceiverRole '../modules/roles/service-bus-receiver-role.bicep' = if
     indexFileQueue
     chunkVideoContent
   ]
+}
+
+
+// Grant Storage Blob Data Contributor role to the identity
+module storageBlobContributorRole '../modules/roles/storage-blob-contributor-role.bicep' = if (!empty(storageAccountName)) {
+  name: '${name}-storage-blob-contributor-role'
+  params: {
+    storageAccountName: storageAccountName
+    containerName: blobContainerName
+    principalId: identity.outputs.principalId
+    appName: name
+  }
+}
+
+// Grant Key Vault Secret User role to the identity
+module keyVaultSecretUserRole '../modules/roles/key-vault-secret-user-role.bicep' = {
+  name: '${name}-key-vault-secret-user-role'
+  params: {
+    keyVaultName: keyVaultName
+    principalId: identity.outputs.principalId
+    appName: name
+  }
 }
 
 output resourceId string = chunkVideoContent.outputs.resourceId

--- a/infra/app-modules/index-file-api.bicep
+++ b/infra/app-modules/index-file-api.bicep
@@ -10,13 +10,6 @@ param applicationInsightsResourceId string
 @description('Resource ID of the Container App Environment')
 param containerAppsEnvironmentResourceId string
 
-@description('Whether the app exists')
-param indexFileApiExists bool
-
-@description('Definition of the app')
-@secure()
-param indexFileApiDefinition object
-
 @description('Secrets for the app')
 @secure()
 param indexFileApiSecrets object
@@ -35,6 +28,9 @@ param abbrs object
 
 @description('Name of the app')
 param name string = 'indexFileApi'
+
+@description('Key Vault name')
+param keyVaultName string
 
 // Create managed identities for the container apps
 module identity 'br/public:avm/res/managed-identity/user-assigned-identity:0.2.1' = {
@@ -63,7 +59,6 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.1.1' =
     ]
   }
 }
-
 // Deploy Index File API Container App
 module indexFileApi '../modules/container-app.bicep' = {
   name: 'indexFileApiContainerApp'
@@ -74,8 +69,6 @@ module indexFileApi '../modules/container-app.bicep' = {
     applicationInsightsResourceId: applicationInsightsResourceId
     containerAppsEnvironmentResourceId: containerAppsEnvironmentResourceId
     containerRegistryLoginServer: containerRegistry.outputs.loginServer
-    exists: indexFileApiExists
-    appDefinition: indexFileApiDefinition
     identityResourceId: identity.outputs.resourceId
     identityClientId: identity.outputs.clientId
     secrets: indexFileApiSecrets
@@ -83,6 +76,7 @@ module indexFileApi '../modules/container-app.bicep' = {
     imageName: 'index-file-api'
   }
   dependsOn: [
+    keyVaultSecretUserRole    // Ensure Key Vault Secret User role exists
     indexFileQueue        // Ensure the index-file queue exists
   ]
 }
@@ -92,8 +86,18 @@ resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' exis
   name: '${serviceBusNamespaceName}/index-file'
 }
 
+// Grant Key Vault Secret User role to the identity
+module keyVaultSecretUserRole '../modules/roles/key-vault-secret-user-role.bicep' = {
+  name: '${name}-key-vault-secret-user-role'
+  params: {
+    keyVaultName: keyVaultName
+    principalId: identity.outputs.principalId
+    appName: name
+  }
+}
+
 // Grant write access to the index file queue using the module
-module indexSenderRole '../modules/roles/service-bus-sender-role.bicep' = if (indexFileApiExists) {
+module indexSenderRole '../modules/roles/service-bus-sender-role.bicep' = {
   name: '${name}-index-sender-role'
   params: {
     serviceBusNamespaceName: serviceBusNamespaceName

--- a/infra/app-modules/summarize-video-content.bicep
+++ b/infra/app-modules/summarize-video-content.bicep
@@ -10,13 +10,6 @@ param applicationInsightsResourceId string
 @description('Resource ID of the Container App Environment')
 param containerAppsEnvironmentResourceId string
 
-@description('Whether the app exists')
-param summarizeVideoContentExists bool
-
-@description('Definition of the app')
-@secure()
-param summarizeVideoContentDefinition object
-
 @description('Secrets for the app')
 @secure()
 param summarizeVideoContentSecrets object
@@ -41,6 +34,9 @@ param abbrs object
 
 @description('Name of the app')
 param name string = 'summarizeVideoContent'
+
+@description('Key Vault name')
+param keyVaultName string
 
 // Create managed identities for the container apps
 module identity 'br/public:avm/res/managed-identity/user-assigned-identity:0.2.1' = {
@@ -69,20 +65,6 @@ module containerRegistry 'br/public:avm/res/container-registry/registry:0.1.1' =
     ]
   }
 }
-
-// Remove the separate ACR pull role assignment module
-
-// Grant Storage Blob Data Contributor role to the identity
-module storageBlobContributorRole '../modules/roles/storage-blob-contributor-role.bicep' = if (!empty(storageAccountName)) {
-  name: '${name}-storage-blob-contributor-role'
-  params: {
-    storageAccountName: storageAccountName
-    containerName: blobContainerName
-    principalId: identity.outputs.principalId
-    appName: name
-  }
-}
-
 // Deploy Summarize Video Content Container App
 module summarizeVideoContent '../modules/container-app.bicep' = {
   name: 'summarizeVideoContentContainerApp'
@@ -93,8 +75,6 @@ module summarizeVideoContent '../modules/container-app.bicep' = {
     applicationInsightsResourceId: applicationInsightsResourceId
     containerAppsEnvironmentResourceId: containerAppsEnvironmentResourceId
     containerRegistryLoginServer: containerRegistry.outputs.loginServer
-    exists: summarizeVideoContentExists
-    appDefinition: summarizeVideoContentDefinition
     identityResourceId: identity.outputs.resourceId
     identityClientId: identity.outputs.clientId
     secrets: summarizeVideoContentSecrets
@@ -102,6 +82,7 @@ module summarizeVideoContent '../modules/container-app.bicep' = {
     imageName: 'summarize-video-content'
   }
   dependsOn: [
+    keyVaultSecretUserRole    // Ensure Key Vault Secret User role exists
     storageBlobContributorRole  // Ensure Storage Blob role exists
     finalizeContentQueue        // Ensure the finalize-content queue exists
     videoSummaryQueue           // Ensure the video-summary queue exists
@@ -125,7 +106,7 @@ resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/container
 }
 
 // Grant read access to the finalize content queue using the module
-module finalizeReceiverRole '../modules/roles/service-bus-receiver-role.bicep' = if (summarizeVideoContentExists) {
+module finalizeReceiverRole '../modules/roles/service-bus-receiver-role.bicep' = {
   name: '${name}-finalize-receiver-role'
   params: {
     serviceBusNamespaceName: serviceBusNamespaceName
@@ -140,7 +121,7 @@ module finalizeReceiverRole '../modules/roles/service-bus-receiver-role.bicep' =
 }
 
 // Grant write access to the video summary queue using the module
-module videoSummarySenderRole '../modules/roles/service-bus-sender-role.bicep' = if (summarizeVideoContentExists) {
+module videoSummarySenderRole '../modules/roles/service-bus-sender-role.bicep' = {
   name: '${name}-video-summary-sender-role'
   params: {
     serviceBusNamespaceName: serviceBusNamespaceName
@@ -154,7 +135,26 @@ module videoSummarySenderRole '../modules/roles/service-bus-sender-role.bicep' =
   ]
 }
 
-// Remove existing Storage Blob Data Reader role assignment
+// Grant Storage Blob Data Contributor role to the identity
+module storageBlobContributorRole '../modules/roles/storage-blob-contributor-role.bicep' = if (!empty(storageAccountName)) {
+  name: '${name}-storage-blob-contributor-role'
+  params: {
+    storageAccountName: storageAccountName
+    containerName: blobContainerName
+    principalId: identity.outputs.principalId
+    appName: name
+  }
+}
+
+// Grant Key Vault Secret User role to the identity
+module keyVaultSecretUserRole '../modules/roles/key-vault-secret-user-role.bicep' = {
+  name: '${name}-key-vault-secret-user-role'
+  params: {
+    keyVaultName: keyVaultName
+    principalId: identity.outputs.principalId
+    appName: name
+  }
+}
 
 output resourceId string = summarizeVideoContent.outputs.resourceId
 output identityPrincipalId string = identity.outputs.principalId

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -9,55 +9,11 @@ param environmentName string
 @description('Primary location for all resources')
 param location string
 
-@description('Service Bus API Key')
-@secure()
-param serviceBusApiKey string = ''
+@description('API version for Content Understanding API')
+param contentUnderstandingApiVersion string = '2023-05-01'
 
-@description('Service Bus API Key Name')
-param serviceBusApiKeyName string = ''
-
-// Setting default values for Content Understanding parameters
-@description('Content Understanding Endpoint')
-param contentUnderstandingEndpoint string = ''
-
-@description('Content Understanding Key')
-@secure()
-param contentUnderstandingKey string = ''
-
-@description('Content Understanding API Version')
-param contentUnderstandingApiVersion string = ''
-
-// Setting default values for Azure OpenAI parameters
-@description('Azure OpenAI Endpoint')
-param azureOpenAIEndpoint string = ''
-
-@description('Azure OpenAI Key')
-@secure()
-param azureOpenAIKey string = ''
-
-@description('Azure OpenAI API Version')
-param azureOpenAIApiVersion string = ''
-
-@description('Azure OpenAI Model Name')
-param azureOpenAIModelName string = ''
-
-// Setting default value for Storage Account API Key
-@description('Storage Account API Key')
-@secure()
-param storageAccountApiKey string = ''
-
-param chunkVideoContentExists bool
-@secure()
-param chunkVideoContentDefinition object
-param indexFileApiExists bool
-@secure()
-param indexFileApiDefinition object
-param summarizeVideoContentExists bool
-@secure()
-param summarizeVideoContentDefinition object
-
-@description('Id of the user or app to assign application roles')
-param principalId string
+@description('API version for Azure OpenAI API')
+param azureOpenaiApiVersion string = '2023-05-15'
 
 // Tags that should be applied to all resources.
 // 
@@ -81,29 +37,11 @@ module resources 'resources.bicep' = {
   params: {
     location: location
     tags: tags
-    principalId: principalId
-    chunkVideoContentExists: chunkVideoContentExists
-    chunkVideoContentDefinition: chunkVideoContentDefinition
-    indexFileApiExists: indexFileApiExists
-    indexFileApiDefinition: indexFileApiDefinition
-    summarizeVideoContentExists: summarizeVideoContentExists
-    summarizeVideoContentDefinition: summarizeVideoContentDefinition
-    // Pass the parameters to resources.bicep
-    serviceBusApiKey: serviceBusApiKey
-    serviceBusApiKeyName: serviceBusApiKeyName
-    contentUnderstandingEndpoint: contentUnderstandingEndpoint
-    contentUnderstandingKey: contentUnderstandingKey
     contentUnderstandingApiVersion: contentUnderstandingApiVersion
-    azureOpenAIEndpoint: azureOpenAIEndpoint
-    azureOpenAIKey: azureOpenAIKey
-    azureOpenAIApiVersion: azureOpenAIApiVersion
-    azureOpenAIModelName: azureOpenAIModelName
-    storageAccountApiKey: storageAccountApiKey
+    azureOpenaiApiVersion: azureOpenaiApiVersion
   }
 }
 
 output AZURE_KEY_VAULT_ENDPOINT string = resources.outputs.AZURE_KEY_VAULT_ENDPOINT
 output AZURE_KEY_VAULT_NAME string = resources.outputs.AZURE_KEY_VAULT_NAME
-output AZURE_RESOURCE_CHUNK_VIDEO_CONTENT_ID string = resources.outputs.AZURE_RESOURCE_CHUNK_VIDEO_CONTENT_ID
-output AZURE_RESOURCE_INDEX_FILE_API_ID string = resources.outputs.AZURE_RESOURCE_INDEX_FILE_API_ID
-output AZURE_RESOURCE_SUMMARIZE_VIDEO_CONTENT_ID string = resources.outputs.AZURE_RESOURCE_SUMMARIZE_VIDEO_CONTENT_ID
+

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -8,6 +8,12 @@
       "location": {
         "value": "${AZURE_LOCATION}"
       },
+      "contentUnderstandingApiVersion": {
+        "value": "${CONTENT_UNDERSTANDING_API_VERSION=2023-05-01}"
+      },
+      "azureOpenaiApiVersion": {
+        "value": "${AZURE_OPENAI_API_VERSION=2023-05-15}"
+      },
       "chunkVideoContentExists": {
         "value": "${SERVICE_CHUNK_VIDEO_CONTENT_RESOURCE_EXISTS=false}"
       },

--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -40,6 +40,12 @@ param aiFoundryProjectDisplayName string = 'Video RAG AI Project'
 @description('Abbreviations to use for resource naming')
 param abbrs object
 
+@description('API version for Content Understanding API')
+param contentUnderstandingApiVersion string = '2023-05-01'
+
+@description('API version for Azure OpenAI API')
+param azureOpenaiApiVersion string = '2023-05-15'
+
 // Create a dedicated container registry for AI services
 module containerRegistry 'br/public:avm/res/container-registry/registry:0.1.1' = {
   name: 'ai-services-registry'
@@ -128,26 +134,57 @@ resource cognitiveServicesAccount 'Microsoft.CognitiveServices/accounts@2023-05-
   }
 }
 
-// Reference to the Key Vault
-resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
-  name: keyVaultName
-}
-
 // Store the Cognitive Services primary key in Key Vault
-resource cognitiveServicesPrimaryKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  parent: keyVault
-  name: 'cognitive-services-primary-key'
+resource contentUnderstandingPrimarySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/content-understanding-key'
   properties: {
     value: cognitiveServicesAccount.listKeys().key1
   }
 }
 
-// Store the Cognitive Services secondary key in Key Vault
-resource cognitiveServicesSecondaryKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  parent: keyVault
-  name: 'cognitive-services-secondary-key'
+// Store the Cognitive Services primary key in Key Vault
+resource contentUnderstandingEndpoint 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/content-understanding-endpoint'
   properties: {
-    value: cognitiveServicesAccount.listKeys().key2
+    value: cognitiveServicesAccount.properties.endpoint
+  }
+}
+
+// Store the Cognitive Services primary key in Key Vault
+resource openAiEndpoint 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/open-ai-endpoint'
+  properties: {
+    value: cognitiveServicesAccount.properties.endpoint
+  }
+}
+
+// Store the Content Understanding API version in Key Vault
+resource contentUnderstandingApiVersionSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/content-understanding-api-version'
+  properties: {
+    value: contentUnderstandingApiVersion
+  }
+}
+
+// Store the Azure OpenAI API version in Key Vault
+resource azureOpenAiApiVersionSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/azure-openai-api-version'
+  properties: {
+    value: azureOpenaiApiVersion
+  }
+}
+
+resource openAiPrimarySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/open-ai-key'
+  properties: {
+    value: cognitiveServicesAccount.listKeys().key1
+  }
+}
+
+resource openAiDeploymentName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/open-ai-deployment-name'
+  properties: {
+    value: gpt4oDeploymentName
   }
 }
 

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -47,7 +47,7 @@ module fetchLatestImage '../modules/fetch-container-image.bicep' = {
   }
 }
 
-// Process secrets with identity
+// Add managed identity to the secret records
 var secretsWithIdentity = [for secret in secrets.secrets: {
   name: secret.name
   keyVaultUrl: secret.keyVaultUrl

--- a/infra/modules/container-app.bicep
+++ b/infra/modules/container-app.bicep
@@ -16,13 +16,6 @@ param containerAppsEnvironmentResourceId string
 @description('Container Registry Login Server')
 param containerRegistryLoginServer string
 
-@description('Whether the app exists (for fetching latest image)')
-param exists bool
-
-@description('App definition with settings')
-@secure()
-param appDefinition object
-
 @description('Identity resource ID')
 param identityResourceId string
 
@@ -45,26 +38,21 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
   scope: resourceGroup(split(applicationInsightsResourceId, '/')[2], split(applicationInsightsResourceId, '/')[4]) // Extract subscription and resource group
 }
 
-// Process app settings
-var settingsArray = filter(array(appDefinition.settings), i => i.name != '')
-var secretSettings = map(filter(settingsArray, i => i.?secret != null), i => {
-  name: i.name
-  value: i.value
-  secretRef: i.?secretRef ?? take(replace(replace(toLower(i.name), '_', '-'), '.', '-'), 32)
-})
-var envSettings = map(filter(settingsArray, i => i.?secret == null), i => {
-  name: i.name
-  value: i.value
-})
-
 // Fetch latest image
 module fetchLatestImage '../modules/fetch-container-image.bicep' = {
   name: '${name}-fetch-image'
   params: {
-    exists: exists
+    exists: false
     name: imageName
   }
 }
+
+// Process secrets with identity
+var secretsWithIdentity = [for secret in secrets.secrets: {
+  name: secret.name
+  keyVaultUrl: secret.keyVaultUrl
+  identity: identityResourceId
+}]
 
 // Deploy container app
 module app 'br/public:avm/res/app/container-app:0.8.0' = {
@@ -75,7 +63,7 @@ module app 'br/public:avm/res/app/container-app:0.8.0' = {
     scaleMinReplicas: 1
     scaleMaxReplicas: 10
     secrets: {
-      secureList: secrets.secrets
+      secureList: secretsWithIdentity
     }
     containers: [
       {
@@ -99,12 +87,8 @@ module app 'br/public:avm/res/app/container-app:0.8.0' = {
             value: '80'
           }
         ],
-        envVars,
-        envSettings,
-        map(secretSettings, secret => {
-            name: secret.name
-            secretRef: secret.secretRef
-        }))
+        envVars
+        )
       }
     ]
     managedIdentities: {

--- a/infra/modules/core-infrastructure.bicep
+++ b/infra/modules/core-infrastructure.bicep
@@ -13,6 +13,8 @@ param keyVaultName string
 var abbrs = loadJsonContent('../abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
 
+var storageAccountName = '${abbrs.storageStorageAccounts}${resourceToken}'
+
 // Monitor application with Azure Monitor
 module monitoring 'br/public:avm/ptn/azd/monitoring:0.1.0' = {
   name: 'monitoring'
@@ -49,10 +51,10 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
         name: 'storage-account-name'
         value: storageAccount.outputs.name
       }
-      // {
-      //   name: 'storage-account-api-key'
-      //   value: storageAccount.
-      // }
+      {
+        name: 'storage-account-api-key'
+        value: listKeys(resourceId('Microsoft.Storage/storageAccounts', storageAccountName), '2022-09-01').keys[0].value
+      }
       {
         name: 'container-name'
         value: blobContainerName
@@ -65,7 +67,7 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
 module storageAccount 'br/public:avm/res/storage/storage-account:0.6.0' = {
   name: 'storage'
   params: {
-    name: '${abbrs.storageStorageAccounts}${resourceToken}'
+    name: storageAccountName
     location: location
     tags: tags
     kind: 'StorageV2'

--- a/infra/modules/core-infrastructure.bicep
+++ b/infra/modules/core-infrastructure.bicep
@@ -4,11 +4,11 @@ param location string = resourceGroup().location
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
-@description('ID of the user or app to assign access policies for Key Vault')
-param principalId string
-
 @description('Name of the blob container to create in the storage account')
 param blobContainerName string = 'videos'
+
+@description('Name of the Key Vault')
+param keyVaultName string
 
 var abbrs = loadJsonContent('../abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
@@ -36,26 +36,28 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.4.5
   }
 }
 
-// Create access policies for all identities
-var accessPolicies = [
-  {
-    objectId: principalId
-    permissions: {
-      secrets: [ 'get', 'list' ]
-    }
-  }
-]
-
 // Deploy Key Vault
 module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
   name: 'keyvault'
   params: {
-    name: '${abbrs.keyVaultVaults}${resourceToken}'
+    name: keyVaultName
     location: location
     tags: tags
-    enableRbacAuthorization: false
-    accessPolicies: accessPolicies
-    secrets: []
+    enableRbacAuthorization: true
+    secrets: [
+      {
+        name: 'storage-account-name'
+        value: storageAccount.outputs.name
+      }
+      // {
+      //   name: 'storage-account-api-key'
+      //   value: storageAccount.
+      // }
+      {
+        name: 'container-name'
+        value: blobContainerName
+      }
+    ]
   }
 }
 

--- a/infra/modules/roles/key-vault-secret-user-role.bicep
+++ b/infra/modules/roles/key-vault-secret-user-role.bicep
@@ -1,0 +1,28 @@
+@description('Key Vault name')
+param keyVaultName string
+
+@description('Principal ID of the identity that needs Key Vault Secret User access')
+param principalId string
+
+@description('Name of the app for description purposes')
+param appName string
+
+// Reference the Key Vault
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
+  name: keyVaultName
+}
+
+// Assign the Key Vault Secrets User role to the identity
+resource keyVaultSecretsUserRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, principalId, 'SecretsUser')
+  scope: keyVault
+  properties: {
+    principalId: principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6') // Key Vault Secrets User
+    principalType: 'ServicePrincipal'
+    description: 'Grant ${appName} app read access to Key Vault secrets'
+  }
+}
+
+// Output the role assignment ID for reference
+output roleAssignmentId string = keyVaultSecretsUserRoleAssignment.id

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -10,6 +10,9 @@ param resourceToken string
 @description('Name prefix abbreviations')
 param abbrs object
 
+@description('The name of the key vault to store secrets')
+param keyVaultName string
+
 // Deploy Service Bus Namespace
 module serviceBus 'br/public:avm/res/service-bus/namespace:0.4.0' = {
   name: 'service-bus'
@@ -21,6 +24,58 @@ module serviceBus 'br/public:avm/res/service-bus/namespace:0.4.0' = {
       name: 'Standard'
       capacity: 1
     }
+  }
+}
+
+resource serviceBusKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-key'
+  properties: {
+    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '${abbrs.serviceBusNamespaces}${resourceToken}', 'RootManageSharedAccessKey'), '2021-11-01').primaryKey
+  }
+  dependsOn: [
+    serviceBus // Ensure Service Bus exists first
+  ]
+}
+
+resource serviceBusKeyName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-api-key-name'
+  properties: {
+    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '${abbrs.serviceBusNamespaces}${resourceToken}', 'RootManageSharedAccessKey'), '2021-11-01').keyName
+  }
+  dependsOn: [
+    serviceBus // Ensure Service Bus exists first
+  ]
+}
+
+// Store the Service Bus namespace name in Key Vault
+resource serviceBusNamespace 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-namespace'
+  properties: {
+    value: '${abbrs.serviceBusNamespaces}${resourceToken}'
+  }
+  dependsOn: [
+    serviceBus // Ensure Service Bus exists first
+  ]
+}
+
+resource indexFileQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/index-file-queue-name'
+  properties: {
+    value: indexFileQueue.name
+  }
+}
+
+resource finalizeContentQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/finalize-content-queue-name'
+  properties: {
+    value: finalizeContentQueue.name
+  }
+}
+
+resource videoSummaryQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/video-summary-queue-name'
+  properties: {
+    value: videoSummaryQueue.name
   }
 }
 

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -4,54 +4,15 @@ param location string = resourceGroup().location
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
-param chunkVideoContentExists bool
-@secure()
-param chunkVideoContentDefinition object
-param indexFileApiExists bool
-@secure()
-param indexFileApiDefinition object
-param summarizeVideoContentExists bool
-@secure()
-param summarizeVideoContentDefinition object
+@description('API version for Content Understanding API')
+param contentUnderstandingApiVersion string = '2023-05-01'
 
-@description('Id of the user or app to assign application roles')
-param principalId string
-
-// Parameters added for service bus secrets
-@secure()
-@description('Service Bus API Key')
-param serviceBusApiKey string = ''
-@description('Service Bus API Key Name')
-param serviceBusApiKeyName string = ''
-
-// Parameters added for content understanding secrets
-@description('Content Understanding Endpoint')
-param contentUnderstandingEndpoint string = ''
-@secure()
-@description('Content Understanding Key')
-param contentUnderstandingKey string = ''
-@description('Content Understanding API Version')
-param contentUnderstandingApiVersion string = ''
-
-// Parameters added for Azure OpenAI secrets
-@description('Azure OpenAI Endpoint')
-param azureOpenAIEndpoint string = ''
-@secure()
-@description('Azure OpenAI Key')
-param azureOpenAIKey string = ''
-@description('Azure OpenAI API Version')
-param azureOpenAIApiVersion string = ''
-@description('Azure OpenAI Model Name')
-param azureOpenAIModelName string = ''
-
-// Parameter added for Storage Account API Key
-@secure()
-@description('Storage Account API Key')
-param storageAccountApiKey string = ''
+@description('API version for Azure OpenAI API')
+param azureOpenaiApiVersion string = '2023-05-15'
 
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = uniqueString(subscription().id, resourceGroup().id, location)
-
+var keyVaultName = '${abbrs.keyVaultVaults}${resourceToken}'
 
 // Deploy core infrastructure (monitoring, container registry, container apps environment, key vault)
 module coreInfra './modules/core-infrastructure.bicep' = {
@@ -59,7 +20,7 @@ module coreInfra './modules/core-infrastructure.bicep' = {
   params: {
     location: location
     tags: tags
-    principalId: principalId
+    keyVaultName: keyVaultName
   }
 }
 
@@ -71,47 +32,143 @@ module serviceBusInfra './modules/service-bus.bicep' = {
     tags: tags
     resourceToken: resourceToken
     abbrs: abbrs
+    keyVaultName: coreInfra.outputs.keyVaultName
   }
 }
 
-// Define secrets by group
-var serviceBusSecrets = [
-  { name: 'service-bus-namespace', value: serviceBusInfra.outputs.serviceBusEndpoint }
-  { name: 'service-bus-api-key', value: !empty(serviceBusApiKey) ? serviceBusApiKey : 'placeholder-value' }
-  { name: 'service-bus-api-key-name', value: !empty(serviceBusApiKeyName) ? serviceBusApiKeyName : 'placeholder-value' }
-  { name: 'index-file-queue', value: serviceBusInfra.outputs.indexFileQueueName }
-  { name: 'finalize-content-queue', value: serviceBusInfra.outputs.finalizeContentQueueName }
-  { name: 'video-summary-queue', value: serviceBusInfra.outputs.videoSummaryQueueName }
-]
-
-var contentSecrets = [
-  { name: 'content-understanding-endpoint', value: !empty(contentUnderstandingEndpoint) ? contentUnderstandingEndpoint : 'placeholder-value' }
-  { name: 'content-understanding-key', value: !empty(contentUnderstandingKey) ? contentUnderstandingKey : 'placeholder-value' }
-  { name: 'content-understanding-api-versio', value: !empty(contentUnderstandingApiVersion) ? contentUnderstandingApiVersion : 'placeholder-value' }
-]
-
-var openAISecrets = [
-  { name: 'azure-openai-endpoint', value: !empty(azureOpenAIEndpoint) ? azureOpenAIEndpoint : 'placeholder-value' }
-  { name: 'azure-openai-key', value: !empty(azureOpenAIKey) ? azureOpenAIKey : 'placeholder-value' }
-  { name: 'azure-openai-api-version', value: !empty(azureOpenAIApiVersion) ? azureOpenAIApiVersion : 'placeholder-value' }
-  { name: 'azure-openai-model-name', value: !empty(azureOpenAIModelName) ? azureOpenAIModelName : 'placeholder-value' }
-]
-
-var storageSecrets = [
-  { name: 'storage-account-api-key', value: !empty(storageAccountApiKey) ? storageAccountApiKey : 'placeholder-value' }
-  { name: 'storage-account-name', value: coreInfra.outputs.storageAccountName }
-  { name: 'storage-container-name', value: coreInfra.outputs.blobContainerName }
-]
-
-// Combine secrets by service
 var chunkVideoContentSecrets = {
-  secrets : concat(serviceBusSecrets, contentSecrets, storageSecrets)
+  secrets : [
+    {
+      name: 'service-bus-namespace'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-namespace'
+    }
+    {
+      name: 'service-bus-api-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-key'
+    }
+    {
+      name: 'service-bus-api-key-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-api-key-name'
+    }
+    {
+      name: 'index-file-queue'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/index-file-queue-name'
+    }
+    {
+      name: 'finalize-content-queue'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/finalize-content-queue-name'
+    }
+    {
+      name: 'content-understanding-endpoint'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-endpoint'
+    }
+    {
+      name: 'content-understanding-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-key'
+    }
+    {
+      name: 'content-understanding-api-version'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-api-version'
+    }
+    {
+      name: 'storage-account-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/storage-account-name'
+    }
+    {
+      name: 'storage-container-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/container-name'
+    }
+    {
+      name: 'storage-account-api-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/storage-account-api-key'
+    }
+  ]
 }
+
 var indexFileApiSecrets = {
-  secrets : serviceBusSecrets
+  secrets : [
+    {
+      name: 'service-bus-namespace'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-namespace'
+    }
+    {
+      name: 'service-bus-api-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-key'
+    }
+    {
+      name: 'service-bus-api-key-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-api-key-name'
+    }
+    {
+      name: 'index-file-queue'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/index-file-queue-name'
+    }
+  ]
 }
+
 var summarizeVideoContentSecrets = {
-  secrets : concat(serviceBusSecrets, openAISecrets, contentSecrets, storageSecrets)
+  secrets : [
+    {
+      name: 'service-bus-namespace'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-namespace'
+    }
+    {
+      name: 'service-bus-api-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-key'
+    }
+    {
+      name: 'service-bus-api-key-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/service-bus-api-key-name'
+    }
+    {
+      name: 'finalize-content-queue'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/finalize-content-queue-name'
+    }
+    {
+      name: 'video-summary-queue'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/video-summary-queue-name'
+    }
+    {
+      name: 'azure-openai-endpoint'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/open-ai-endpoint'
+    }
+    {
+      name: 'azure-openai-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/open-ai-key'
+    }
+    {
+      name: 'azure-openai-api-version'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/azure-openai-api-version'
+    }
+    {
+      name: 'azure-openai-model-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/open-ai-deployment-name'
+    }
+    {
+      name: 'content-understanding-endpoint'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-endpoint'
+    }
+    {
+      name: 'content-understanding-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-key'
+    }
+    {
+      name: 'content-understanding-api-version'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/content-understanding-api-version'
+    }
+    {
+      name: 'storage-account-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/storage-account-name'
+    }
+    {
+      name: 'storage-container-name'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/container-name'
+    }
+    {
+      name: 'storage-account-api-key'
+      keyVaultUrl: '${coreInfra.outputs.keyVaultUri}secrets/storage-account-api-key'
+    }
+  ]
 }
 
 // Define environment variables by service
@@ -123,7 +180,7 @@ var chunkVideoContentEnvVars = [
   { name: 'FINALIZE_CONTENT_QUEUE', secretRef: 'finalize-content-queue' }
   { name: 'CONTENT_UNDERSTANDING_ENDPOINT', secretRef: 'content-understanding-endpoint' }
   { name: 'CONTENT_UNDERSTANDING_KEY', secretRef: 'content-understanding-key' }
-  { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-versio' }
+  { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-version' }
   { name: 'STORAGE_ACCOUNT_NAME', secretRef: 'storage-account-name' }
   { name: 'STORAGE_CONTAINER_NAME', secretRef: 'storage-container-name' }
   { name: 'STORAGE_ACCOUNT_API_KEY', secretRef: 'storage-account-api-key' }
@@ -148,13 +205,14 @@ var summarizeVideoContentEnvVars = [
   { name: 'AZURE_OPENAI_MODEL_NAME', secretRef: 'azure-openai-model-name' }
   { name: 'CONTENT_UNDERSTANDING_ENDPOINT', secretRef: 'content-understanding-endpoint' }
   { name: 'CONTENT_UNDERSTANDING_KEY', secretRef: 'content-understanding-key' }
-  { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-versio' }
+  { name: 'CONTENT_UNDERSTANDING_API_VERSION', secretRef: 'content-understanding-api-version' }
   { name: 'STORAGE_ACCOUNT_NAME', secretRef: 'storage-account-name' }
   { name: 'STORAGE_CONTAINER_NAME', secretRef: 'storage-container-name' }
   { name: 'STORAGE_ACCOUNT_API_KEY', secretRef: 'storage-account-api-key' }
 ]
 
-// Deploy individual container apps
+// Deploy individual container apps - we need to deploy in two steps
+// First, deploy the app to get the identity ID
 module chunkVideoContentApp './app-modules/chunk-video-content.bicep' = {
   name: 'chunk-video-content-app'
   params: {
@@ -162,8 +220,6 @@ module chunkVideoContentApp './app-modules/chunk-video-content.bicep' = {
     tags: tags
     applicationInsightsResourceId: coreInfra.outputs.applicationInsightsResourceId
     containerAppsEnvironmentResourceId: coreInfra.outputs.containerAppsEnvironmentResourceId
-    chunkVideoContentExists: chunkVideoContentExists
-    chunkVideoContentDefinition: chunkVideoContentDefinition
     chunkVideoContentSecrets: chunkVideoContentSecrets
     chunkVideoContentEnvVars: chunkVideoContentEnvVars
     serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
@@ -171,9 +227,12 @@ module chunkVideoContentApp './app-modules/chunk-video-content.bicep' = {
     blobContainerName: coreInfra.outputs.blobContainerName
     abbrs: abbrs
     resourceToken: resourceToken
+    keyVaultName: coreInfra.outputs.keyVaultName
   }
 }
 
+
+// First, deploy the app to get the identity ID
 module indexFileApiApp './app-modules/index-file-api.bicep' = {
   name: 'index-file-api-app'
   params: {
@@ -181,17 +240,16 @@ module indexFileApiApp './app-modules/index-file-api.bicep' = {
     tags: tags
     applicationInsightsResourceId: coreInfra.outputs.applicationInsightsResourceId
     containerAppsEnvironmentResourceId: coreInfra.outputs.containerAppsEnvironmentResourceId
-    // Remove containerRegistryLoginServer parameter since it's created in the module
-    indexFileApiExists: indexFileApiExists
-    indexFileApiDefinition: indexFileApiDefinition
     indexFileApiSecrets: indexFileApiSecrets
     indexFileApiEnvVars: indexFileApiEnvVars
     serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
     abbrs: abbrs
     resourceToken: resourceToken
+    keyVaultName: coreInfra.outputs.keyVaultName
   }
 }
 
+// First, deploy the app to get the identity ID
 module summarizeVideoContentApp './app-modules/summarize-video-content.bicep' = {
   name: 'summarize-video-content-app'
   params: {
@@ -199,9 +257,6 @@ module summarizeVideoContentApp './app-modules/summarize-video-content.bicep' = 
     tags: tags
     applicationInsightsResourceId: coreInfra.outputs.applicationInsightsResourceId
     containerAppsEnvironmentResourceId: coreInfra.outputs.containerAppsEnvironmentResourceId
-    // Remove containerRegistryLoginServer parameter since it's created in the module
-    summarizeVideoContentExists: summarizeVideoContentExists
-    summarizeVideoContentDefinition: summarizeVideoContentDefinition
     summarizeVideoContentSecrets: summarizeVideoContentSecrets
     summarizeVideoContentEnvVars: summarizeVideoContentEnvVars
     serviceBusNamespaceName: serviceBusInfra.outputs.serviceBusNamespaceName
@@ -209,6 +264,7 @@ module summarizeVideoContentApp './app-modules/summarize-video-content.bicep' = 
     blobContainerName: coreInfra.outputs.blobContainerName
     abbrs: abbrs
     resourceToken: resourceToken
+    keyVaultName: coreInfra.outputs.keyVaultName
   }
 }
 
@@ -229,6 +285,8 @@ module aiServices './modules/ai-services.bicep' = {
     aiFoundryProjectName: '${abbrs.machineLearningServicesWorkspaces}${resourceToken}-project'
     aiFoundryProjectDisplayName: 'Video RAG Pipeline Project'
     abbrs: abbrs
+    contentUnderstandingApiVersion: contentUnderstandingApiVersion
+    azureOpenaiApiVersion: azureOpenaiApiVersion
   }
 }
 
@@ -244,9 +302,6 @@ output AZURE_COGNITIVE_SERVICES_NAME string = aiServices.outputs.cognitiveServic
 output AZURE_COGNITIVE_SERVICES_ID string = aiServices.outputs.cognitiveServicesAccountId
 output AZURE_COGNITIVE_SERVICES_ENDPOINT string = aiServices.outputs.cognitiveServicesEndpoint
 output AZURE_GPT4O_DEPLOYMENT_NAME string = aiServices.outputs.gpt4oDeploymentName
-output AZURE_RESOURCE_CHUNK_VIDEO_CONTENT_ID string = chunkVideoContentApp.outputs.resourceId
-output AZURE_RESOURCE_INDEX_FILE_API_ID string = indexFileApiApp.outputs.resourceId
-output AZURE_RESOURCE_SUMMARIZE_VIDEO_CONTENT_ID string = summarizeVideoContentApp.outputs.resourceId
 output AZURE_SERVICE_BUS_NAMESPACE string = serviceBusInfra.outputs.serviceBusNamespaceName
 output AZURE_SERVICE_BUS_ENDPOINT string = serviceBusInfra.outputs.serviceBusEndpoint
 output AZURE_INDEX_FILE_QUEUE string = serviceBusInfra.outputs.indexFileQueueName


### PR DESCRIPTION
- Populate key vault secrets from resource outputs
- Deprecate parameters used to supply resource info before bicep templates existed
- Enable RBAC authorization in KeyVault so managed identities can easily access secrets
- Populate AI API Versions with a default value because it's not retrievable through bicep
- Remove `if[app]Exists` parameters becausethey will always exist

Infrastructure successfully deploys, indicating ACA was able to retrieve the secrets