### PR TITLE
feat: add content understanding script and refactor secrets

### DIFF
--- a/infra/modules/ai-services.bicep
+++ b/infra/modules/ai-services.bicep
@@ -115,7 +115,6 @@ resource aiServiceConnection 'Microsoft.MachineLearningServices/workspaces/conne
   }
 }
 
-
 // Add Cognitive Services account of kind AIServices
 resource cognitiveServicesAccount 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: cognitiveServicesAccountName
@@ -134,6 +133,8 @@ resource cognitiveServicesAccount 'Microsoft.CognitiveServices/accounts@2023-05-
   }
 }
 
+var contentUnderstandingEndpoint = 'https://${cognitiveServicesAccountName}.services.microsoft.com/'
+
 // Store the Cognitive Services primary key in Key Vault
 resource contentUnderstandingPrimarySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   name: '${keyVaultName}/content-understanding-key'
@@ -143,10 +144,10 @@ resource contentUnderstandingPrimarySecret 'Microsoft.KeyVault/vaults/secrets@20
 }
 
 // Store the Cognitive Services primary key in Key Vault
-resource contentUnderstandingEndpoint 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+resource contentUnderstandingEndpointSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
   name: '${keyVaultName}/content-understanding-endpoint'
   properties: {
-    value: cognitiveServicesAccount.properties.endpoint
+    value: contentUnderstandingEndpoint
   }
 }
 
@@ -292,6 +293,7 @@ resource deployGpt4oModel 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
 output cognitiveServicesAccountName string = cognitiveServicesAccount.name
 output cognitiveServicesAccountId string = cognitiveServicesAccount.id
 output cognitiveServicesEndpoint string = cognitiveServicesAccount.properties.endpoint
+output contentUnderstandingEndpoint string = contentUnderstandingEndpoint
 output gpt4oDeploymentName string = gpt4oDeploymentName
 output aiProjectName string = aiProject.name
 output aiProjectId string = aiProject.id

--- a/infra/modules/content-understanding-setup.bicep
+++ b/infra/modules/content-understanding-setup.bicep
@@ -1,0 +1,130 @@
+@description('The location used for all deployed resources')
+param location string = resourceGroup().location
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('Endpoint URL of the Cognitive Services account')
+param contentUnderstandingEndpoint string
+
+@description('API key for the Cognitive Services account')
+@secure()
+param contentUnderstandingKey string
+
+@description('Resource token for unique resource naming')
+param resourceToken string
+
+@description('Name of the Content Understanding analyzer to create')
+param analyzerName string = 'video-content-analyzer'
+
+@description('The name of the Cognitive Services account')
+param cognitiveServicesAccountName string
+
+var analyzerFilePath = '../schemas/content-analyzer.json'
+
+// Load analyzer definition from JSON file
+var analyzerDefinition = loadJsonContent(analyzerFilePath)
+
+// User-assigned managed identity for the deployment script
+resource deploymentScriptIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-contentunderstanding-${resourceToken}'
+  location: location
+  tags: tags
+}
+
+// Reference to the Cognitive Services account
+resource cognitiveService 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = {
+  name: cognitiveServicesAccountName
+}
+
+// Create a completely unique role assignment ID that won't conflict
+var roleGuid = guid('cognitive-services-contributor', resourceGroup().id, deploymentScriptIdentity.id, cognitiveServicesAccountName, resourceToken)
+
+// Create role assignment for the deployment script identity to manage Cognitive Services
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: roleGuid
+  scope: cognitiveService
+  properties: {
+    principalId: deploymentScriptIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68') // Cognitive Services Contributor
+    principalType: 'ServicePrincipal'
+    description: 'Grant Content Understanding setup script permission to manage Cognitive Services'
+  }
+}
+
+// Deployment script to create the analyzer
+resource contentUnderstandingSetup 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: 'deployContentUnderstanding'
+  location: location
+  tags: tags
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${deploymentScriptIdentity.id}': {}
+    }
+  }
+  dependsOn: [
+    roleAssignment
+  ]
+  properties: {
+    azCliVersion: '2.69.0'
+    timeout: 'PT30M'
+    retentionInterval: 'P1D'
+    environmentVariables: [
+      {
+        name: 'ANALYZER_NAME'
+        value: analyzerName
+      }
+      {
+        name: 'ANALYZER_CONTENT'
+        value: string(analyzerDefinition)
+      }
+      {
+        name: 'CONTENT_UNDERSTANDING_ENDPOINT'
+        value: contentUnderstandingEndpoint
+      }
+      {
+        name: 'CONTENT_UNDERSTANDING_KEY'
+        secureValue: contentUnderstandingKey
+      }
+    ]
+    scriptContent: '''
+      #!/bin/bash
+      set -e
+      
+      echo "Setting up Content Understanding resources..."
+      
+      # Create analyzer definition file using content from environment variable
+      echo "Creating analyzer definition file..."
+      echo $ANALYZER_CONTENT > analyzer.json
+      
+      # Use the endpoint and key provided by parameters
+      ENDPOINT=$CONTENT_UNDERSTANDING_ENDPOINT
+      API_KEY=$CONTENT_UNDERSTANDING_KEY
+      API_VERSION="2024-12-01-preview"
+      
+      # Check if analyzer already exists
+      echo "Checking if analyzer $ANALYZER_NAME already exists..."
+      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+        "${ENDPOINT}contentunderstanding/analyzers/${ANALYZER_NAME}?api-version=${API_VERSION}" \
+        -H "Ocp-Apim-Subscription-Key: $API_KEY")
+      
+      if [ "$HTTP_CODE" == "200" ]; then
+        echo "Analyzer $ANALYZER_NAME already exists. Skipping creation."
+      else
+        echo "Analyzer not found. Creating analyzer $ANALYZER_NAME..."
+        # Deploy the analyzer using curl
+        curl -v -X PUT \
+          "${ENDPOINT}contentunderstanding/analyzers/${ANALYZER_NAME}?api-version=${API_VERSION}" \
+          -H "Content-Type: application/json" \
+          -H "Ocp-Apim-Subscription-Key: $API_KEY" \
+          -d @analyzer.json
+        
+        echo "Content Understanding analyzer created successfully."
+      fi
+    '''
+  }
+}
+
+output analyzerName string = analyzerName

--- a/infra/modules/content-understanding-setup.bicep
+++ b/infra/modules/content-understanding-setup.bicep
@@ -20,6 +20,9 @@ param analyzerName string = 'video-content-analyzer'
 @description('The name of the Cognitive Services account')
 param cognitiveServicesAccountName string
 
+@description('API version for Content Understanding services')
+param apiVersion string = '2024-12-01-preview'
+
 var analyzerFilePath = '../schemas/content-analyzer.json'
 
 // Load analyzer definition from JSON file
@@ -88,6 +91,10 @@ resource contentUnderstandingSetup 'Microsoft.Resources/deploymentScripts@2020-1
         name: 'CONTENT_UNDERSTANDING_KEY'
         secureValue: contentUnderstandingKey
       }
+      {
+        name: 'API_VERSION'
+        value: apiVersion
+      }
     ]
     scriptContent: '''
       #!/bin/bash
@@ -102,7 +109,7 @@ resource contentUnderstandingSetup 'Microsoft.Resources/deploymentScripts@2020-1
       # Use the endpoint and key provided by parameters
       ENDPOINT=$CONTENT_UNDERSTANDING_ENDPOINT
       API_KEY=$CONTENT_UNDERSTANDING_KEY
-      API_VERSION="2024-12-01-preview"
+      API_VERSION=$API_VERSION
       
       # Check if analyzer already exists
       echo "Checking if analyzer $ANALYZER_NAME already exists..."

--- a/infra/modules/core-infrastructure.bicep
+++ b/infra/modules/core-infrastructure.bicep
@@ -38,34 +38,9 @@ module containerAppsEnvironment 'br/public:avm/res/app/managed-environment:0.4.5
   }
 }
 
-// Deploy Key Vault
-module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
-  name: 'keyvault'
-  params: {
-    name: keyVaultName
-    location: location
-    tags: tags
-    enableRbacAuthorization: true
-    secrets: [
-      {
-        name: 'storage-account-name'
-        value: storageAccount.outputs.name
-      }
-      {
-        name: 'storage-account-api-key'
-        value: listKeys(resourceId('Microsoft.Storage/storageAccounts', storageAccountName), '2022-09-01').keys[0].value
-      }
-      {
-        name: 'container-name'
-        value: blobContainerName
-      }
-    ]
-  }
-}
-
 // Deploy Storage Account
 module storageAccount 'br/public:avm/res/storage/storage-account:0.6.0' = {
-  name: 'storage'
+  name: 'storage'  // Changed from storageAccountName to 'storage' to match proper module naming
   params: {
     name: storageAccountName
     location: location
@@ -78,15 +53,34 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.6.0' = {
   }
 }
 
-// Create Blob Container in Storage Account
+// Create Blob Service for the Storage Account first
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
+  name: '${storageAccountName}/default'
+  dependsOn: [
+    storageAccount
+  ]
+}
+
+// Create Blob Container in Storage Account with proper parent/child relationship
 resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
-  name: '${abbrs.storageStorageAccounts}${resourceToken}/default/${blobContainerName}'
+  name: '${storageAccountName}/default/${blobContainerName}'
   properties: {
     publicAccess: 'None'
   }
   dependsOn: [
-    storageAccount // Ensure the Storage Account exists
+    blobService // Depend on blob service instead of directly on storage account
   ]
+}
+
+// Deploy Key Vault without inline secrets
+module keyVault 'br/public:avm/res/key-vault/vault:0.6.1' = {
+  name: 'keyvault'
+  params: {
+    name: keyVaultName
+    location: location
+    tags: tags
+    enableRbacAuthorization: true
+  }
 }
 
 output logAnalyticsWorkspaceResourceId string = monitoring.outputs.logAnalyticsWorkspaceResourceId

--- a/infra/modules/core-infrastructure.bicep
+++ b/infra/modules/core-infrastructure.bicep
@@ -53,14 +53,6 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.6.0' = {
   }
 }
 
-// Create Blob Service for the Storage Account first
-resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' = {
-  name: '${storageAccountName}/default'
-  dependsOn: [
-    storageAccount
-  ]
-}
-
 // Create Blob Container in Storage Account with proper parent/child relationship
 resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
   name: '${storageAccountName}/default/${blobContainerName}'
@@ -68,7 +60,7 @@ resource blobContainer 'Microsoft.Storage/storageAccounts/blobServices/container
     publicAccess: 'None'
   }
   dependsOn: [
-    blobService // Depend on blob service instead of directly on storage account
+    storageAccount
   ]
 }
 

--- a/infra/modules/secrets.bicep
+++ b/infra/modules/secrets.bicep
@@ -1,0 +1,86 @@
+@description('The name of the Key Vault to store secrets')
+param keyVaultName string
+
+@description('The name of the Service Bus namespace')
+param serviceBusNamespace string
+
+@description('The name of the blob container')
+param blobContainerName string
+
+@description('The name of the Storage Account')
+param storageAccountName string
+
+// Store Storage Account API Key in Key Vault
+resource storageAccountApiKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/storage-account-api-key'
+  properties: {
+    value: listKeys(resourceId('Microsoft.Storage/storageAccounts', storageAccountName), '2022-09-01').keys[0].value
+  }
+}
+
+// Secrets are in a dedicated module so we can make the module dependent on other
+// resources. The listKeys function does not respect dependsOn applied directly
+// to the resource
+// https://github.com/Azure/bicep/issues/7402
+
+// Service Bus primary key secret
+resource serviceBusKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-key'
+  properties: {
+    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', serviceBusNamespace, 'RootManageSharedAccessKey'), '2021-11-01').primaryKey
+  }
+}
+
+// Service Bus key name secret
+resource serviceBusKeyNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-api-key-name'
+  properties: {
+    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', serviceBusNamespace, 'RootManageSharedAccessKey'), '2021-11-01').keyName
+  }
+}
+
+// Store the Service Bus namespace name in Key Vault
+resource serviceBusNamespaceSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/service-bus-namespace'
+  properties: {
+    value: serviceBusNamespace
+  }
+}
+
+resource indexFileQueueNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/index-file-queue-name'
+  properties: {
+    value: 'index-file'
+  }
+}
+
+resource finalizeContentQueueNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/finalize-content-queue-name'
+  properties: {
+    value: 'finalize-content'
+  }
+}
+
+resource videoSummaryQueueNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/video-summary-queue-name'
+  properties: {
+    value: 'video-summary'
+  }
+}
+
+
+// Store simple secrets in Key Vault
+resource storageAccountNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/storage-account-name'
+  properties: {
+    value: storageAccountName
+  }
+}
+
+// Store Container Name in Key Vault
+resource containerNameSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
+  name: '${keyVaultName}/container-name'
+  properties: {
+    value: blobContainerName
+  }
+}

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -27,58 +27,6 @@ module serviceBus 'br/public:avm/res/service-bus/namespace:0.4.0' = {
   }
 }
 
-resource serviceBusKeySecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/service-bus-key'
-  properties: {
-    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '${abbrs.serviceBusNamespaces}${resourceToken}', 'RootManageSharedAccessKey'), '2021-11-01').primaryKey
-  }
-  dependsOn: [
-    serviceBus // Ensure Service Bus exists first
-  ]
-}
-
-resource serviceBusKeyName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/service-bus-api-key-name'
-  properties: {
-    value: listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', '${abbrs.serviceBusNamespaces}${resourceToken}', 'RootManageSharedAccessKey'), '2021-11-01').keyName
-  }
-  dependsOn: [
-    serviceBus // Ensure Service Bus exists first
-  ]
-}
-
-// Store the Service Bus namespace name in Key Vault
-resource serviceBusNamespace 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/service-bus-namespace'
-  properties: {
-    value: '${abbrs.serviceBusNamespaces}${resourceToken}'
-  }
-  dependsOn: [
-    serviceBus // Ensure Service Bus exists first
-  ]
-}
-
-resource indexFileQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/index-file-queue-name'
-  properties: {
-    value: indexFileQueue.name
-  }
-}
-
-resource finalizeContentQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/finalize-content-queue-name'
-  properties: {
-    value: finalizeContentQueue.name
-  }
-}
-
-resource videoSummaryQueueName 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  name: '${keyVaultName}/video-summary-queue-name'
-  properties: {
-    value: videoSummaryQueue.name
-  }
-}
-
 // Create a queue for indexing files
 resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = {
   name: '${abbrs.serviceBusNamespaces}${resourceToken}/index-file'
@@ -95,7 +43,7 @@ resource indexFileQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' = {
     enableExpress: false
   }
   dependsOn: [
-    serviceBus // Ensure the Service Bus namespace exists
+    serviceBus // Ensure the Service Bus namespace is fully provisioned
   ]
 }
 
@@ -115,7 +63,7 @@ resource finalizeContentQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01
     enableExpress: false
   }
   dependsOn: [
-    serviceBus // Ensure the Service Bus namespace exists
+    serviceBus // Ensure the Service Bus namespace is fully provisioned
   ]
 }
 
@@ -135,7 +83,7 @@ resource videoSummaryQueue 'Microsoft.ServiceBus/namespaces/queues@2021-11-01' =
     enableExpress: false
   }
   dependsOn: [
-    serviceBus // Ensure the Service Bus namespace exists
+    serviceBus // Ensure the Service Bus namespace is fully provisioned
   ]
 }
 

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -36,6 +36,21 @@ module serviceBusInfra './modules/service-bus.bicep' = {
   }
 }
 
+// Module for Service Bus key secrets 
+module secrets './modules/secrets.bicep' = {
+  name: 'service-bus-key-secrets'
+  params: {
+    keyVaultName: keyVaultName
+    serviceBusNamespace: '${abbrs.serviceBusNamespaces}${resourceToken}'
+    blobContainerName: coreInfra.outputs.blobContainerName
+    storageAccountName: coreInfra.outputs.storageAccountName
+  }
+  dependsOn: [
+    serviceBusInfra
+  ]
+}
+
+
 var chunkVideoContentSecrets = {
   secrets : [
     {
@@ -229,8 +244,10 @@ module chunkVideoContentApp './app-modules/chunk-video-content.bicep' = {
     resourceToken: resourceToken
     keyVaultName: coreInfra.outputs.keyVaultName
   }
+  dependsOn: [
+    secrets
+  ]
 }
-
 
 // First, deploy the app to get the identity ID
 module indexFileApiApp './app-modules/index-file-api.bicep' = {
@@ -247,6 +264,9 @@ module indexFileApiApp './app-modules/index-file-api.bicep' = {
     resourceToken: resourceToken
     keyVaultName: coreInfra.outputs.keyVaultName
   }
+  dependsOn: [
+    secrets
+  ]
 }
 
 // First, deploy the app to get the identity ID
@@ -266,6 +286,9 @@ module summarizeVideoContentApp './app-modules/summarize-video-content.bicep' = 
     resourceToken: resourceToken
     keyVaultName: coreInfra.outputs.keyVaultName
   }
+  dependsOn: [
+    secrets
+  ]
 }
 
 // Deploy the Foundry Hub from the module
@@ -289,6 +312,23 @@ module aiServices './modules/ai-services.bicep' = {
     azureOpenaiApiVersion: azureOpenaiApiVersion
   }
 }
+
+// Deploy Content Understanding Schema and Analyzer setup
+module contentUnderstandingSetup './modules/content-understanding-setup.bicep' = {
+  name: 'content-understanding-setup'
+  params: {
+    location: location
+    tags: tags
+    cognitiveServicesAccountName: aiServices.outputs.cognitiveServicesAccountName
+    contentUnderstandingEndpoint: aiServices.outputs.cognitiveServicesEndpoint
+    contentUnderstandingKey: aiServices.outputs.contentUnderstandingEndpoint
+    resourceToken: resourceToken
+    analyzerName: 'video-content-analyzer'
+  }
+}
+
+// Add new outputs for Content Understanding
+output AZURE_CONTENT_UNDERSTANDING_ANALYZER string = contentUnderstandingSetup.outputs.analyzerName
 
 output AZURE_KEY_VAULT_ENDPOINT string = coreInfra.outputs.keyVaultUri
 output AZURE_KEY_VAULT_NAME string = coreInfra.outputs.keyVaultName

--- a/infra/schemas/content-analyzer.json
+++ b/infra/schemas/content-analyzer.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+      "returnDetails": true,
+      "disableContentFiltering": true
+    },
+    "description": "Sample video analyzer",
+    "scenario": "videoShot",
+    "fieldSchema": {
+      "fields": {
+        "description": {
+          "type": "string",
+          "description": "Write a description of what occurs in the video segment and who the actors are as if it were a screenplay."
+        },
+        "subject": {
+          "type": "string",
+          "description": "Categorize the description to determine the main topic and purpose of the video segment."
+        }
+      }
+    }
+  }

--- a/next-steps.md
+++ b/next-steps.md
@@ -12,43 +12,6 @@
 
 You need to run ```uv pip lock > requirements.txt``` on each project before running azd up.
 
-##### Content Understanding
-
-Content understanding needs to have a schema and analyzer.
-This can be done through the API, but won't show up in the Online UI. THIS IS A KNOWN BUG.
-To configure through the API, use the following script:
-
-curl:
-
-```
-curl -X PUT -H "Content-Type: application/json" -d @data.json https://{AISERVICESURL}.services.ai.azure.com/contentunderstanding/analyzers/{NAME}?api-version=2024-12-01-preview
-```
-
-data.json:
-
-```
-{
-  "config": {
-    "returnDetails": true,
-    "disableContentFiltering": true
-  },
-  "description": "Sample video analyzer",
-  "scenario": "videoShot",
-  "fieldSchema": {
-    "fields": {
-      "description": {
-        "type": "string",
-        "description": "Write a description of what occurs in the video segment and who the actors are as if it were a screenplay."
-      },
-      "subject": {
-        "type": "string",
-        "description": "Categorize the description to determine the main topic and purpose of the video segment."
-      }
-    }
-  }
-}
-```
-
 ## Next Steps
 
 ### Provision infrastructure and deploy application code


### PR DESCRIPTION
- Add content understanding script, run by bicep, to create the schema and analyzer
- Refactor ai-services.bicep to pass back the Content Understanding endpoint, which differs from the main cognitive services endpoint. This is semi-hardcoded based on convention because the endpoint is not available to bicep.
- Refactor secrets to their own module where I can add a `dependsOn` to ensure dependencies have deployed first. The `listKeys` function has a [bug](https://github.com/Azure/bicep/issues/7402) that enables it to run prior to dependencies if the `dependsOn` is directly on the secret resource.
- Update `next-steps.md` with latest changes